### PR TITLE
feat: Add client-side data caching for faster navigation

### DIFF
--- a/client/src/contexts/DataContext.tsx
+++ b/client/src/contexts/DataContext.tsx
@@ -1,0 +1,106 @@
+import { AboutData, HomeContent, Project } from "@/types";
+import React, { createContext, ReactNode, useContext, useState } from "react";
+
+interface Skill {
+  _id: string;
+  name: string;
+  x: string;
+  y: string;
+  order: number;
+}
+
+interface DataContextType {
+  // Home data
+  homeData: HomeContent | null;
+  setHomeData: (data: HomeContent | null) => void;
+  homeLoaded: boolean;
+  setHomeLoaded: (loaded: boolean) => void;
+
+  // About data
+  aboutData: AboutData | null;
+  setAboutData: (data: AboutData | null) => void;
+  aboutLoaded: boolean;
+  setAboutLoaded: (loaded: boolean) => void;
+
+  // Projects data
+  projectsData: Project[];
+  setProjectsData: (data: Project[]) => void;
+  projectsLoaded: boolean;
+  setProjectsLoaded: (loaded: boolean) => void;
+
+  // Skills data
+  skillsData: Skill[];
+  setSkillsData: (data: Skill[]) => void;
+  skillsLoaded: boolean;
+  setSkillsLoaded: (loaded: boolean) => void;
+
+  // Clear all cache (useful for logout or refresh)
+  clearCache: () => void;
+}
+
+const DataContext = createContext<DataContextType | undefined>(undefined);
+
+export const DataProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  // Home state
+  const [homeData, setHomeData] = useState<HomeContent | null>(null);
+  const [homeLoaded, setHomeLoaded] = useState(false);
+
+  // About state
+  const [aboutData, setAboutData] = useState<AboutData | null>(null);
+  const [aboutLoaded, setAboutLoaded] = useState(false);
+
+  // Projects state
+  const [projectsData, setProjectsData] = useState<Project[]>([]);
+  const [projectsLoaded, setProjectsLoaded] = useState(false);
+
+  // Skills state
+  const [skillsData, setSkillsData] = useState<Skill[]>([]);
+  const [skillsLoaded, setSkillsLoaded] = useState(false);
+
+  const clearCache = () => {
+    setHomeData(null);
+    setHomeLoaded(false);
+    setAboutData(null);
+    setAboutLoaded(false);
+    setProjectsData([]);
+    setProjectsLoaded(false);
+    setSkillsData([]);
+    setSkillsLoaded(false);
+  };
+
+  return (
+    <DataContext.Provider
+      value={{
+        homeData,
+        setHomeData,
+        homeLoaded,
+        setHomeLoaded,
+        aboutData,
+        setAboutData,
+        aboutLoaded,
+        setAboutLoaded,
+        projectsData,
+        setProjectsData,
+        projectsLoaded,
+        setProjectsLoaded,
+        skillsData,
+        setSkillsData,
+        skillsLoaded,
+        setSkillsLoaded,
+        clearCache,
+      }}
+    >
+      {children}
+    </DataContext.Provider>
+  );
+};
+
+export const useDataContext = () => {
+  const context = useContext(DataContext);
+  if (context === undefined) {
+    throw new Error("useDataContext must be used within a DataProvider");
+  }
+  return context;
+};

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import Head from "next/head";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import { AuthProvider } from "../contexts/AuthContext";
+import { DataProvider } from "../contexts/DataContext";
 
 const nunito = Nunito({
   subsets: ["latin"],
@@ -22,26 +23,28 @@ export default function App({ Component, pageProps }: AppProps) {
       </Head>
 
       <AuthProvider>
-        <main
-          className={`${nunito.variable} font-nunito bg-light  dark:bg-dark w-full min-h-screen`}
-        >
-          <NavBar />
+        <DataProvider>
+          <main
+            className={`${nunito.variable} font-nunito bg-light  dark:bg-dark w-full min-h-screen`}
+          >
+            <NavBar />
 
-          <ToastContainer
-            position="top-right"
-            autoClose={3000}
-            hideProgressBar={false}
-            newestOnTop={false}
-            closeOnClick
-            rtl={false}
-            pauseOnFocusLoss
-            draggable
-            pauseOnHover
-          />
-          <Component {...pageProps} />
+            <ToastContainer
+              position="top-right"
+              autoClose={3000}
+              hideProgressBar={false}
+              newestOnTop={false}
+              closeOnClick
+              rtl={false}
+              pauseOnFocusLoss
+              draggable
+              pauseOnHover
+            />
+            <Component {...pageProps} />
 
-          <Footer />
-        </main>
+            <Footer />
+          </main>
+        </DataProvider>
       </AuthProvider>
     </>
   );

--- a/client/src/pages/about.tsx
+++ b/client/src/pages/about.tsx
@@ -6,7 +6,7 @@ import { Layout } from "@/components/Layout";
 import SkillAndCertifications from "@/components/SkillAndCertifications";
 import Skills from "@/components/Skills";
 import TransitionEffect from "@/components/TransitionEffect";
-import { AboutData } from "@/types";
+import { useDataContext } from "@/contexts/DataContext";
 import urlConfig from "@/utils/urlConfig";
 import axios from "axios";
 import { useInView, useMotionValue, useSpring } from "framer-motion";
@@ -43,26 +43,30 @@ const AnimatedNumbers: React.FC<AnimatedNumbersProps> = ({ value }) => {
 };
 
 const About: React.FC = () => {
-  const [aboutData, setAboutData] = useState<AboutData | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
+  const { aboutData, setAboutData, aboutLoaded, setAboutLoaded } =
+    useDataContext();
+  const [loading, setLoading] = useState<boolean>(!aboutLoaded);
 
   useEffect(() => {
-    const fetchAbout = async () => {
-      try {
-        const response = await axios.get(urlConfig.GET_ABOUT);
-        if (response.data.data) {
-          setAboutData(response.data.data);
+    if (!aboutLoaded) {
+      const fetchAbout = async () => {
+        try {
+          const response = await axios.get(urlConfig.GET_ABOUT);
+          if (response.data.data) {
+            setAboutData(response.data.data);
+          }
+          setAboutLoaded(true);
+        } catch (error) {
+          console.error("Error fetching about data:", error);
+          setAboutLoaded(true);
+        } finally {
+          setLoading(false);
         }
-      } catch (error) {
-        console.error("Error fetching about data:", error);
-        // Continue with default content if API fails
-      } finally {
-        setLoading(false);
-      }
-    };
+      };
 
-    fetchAbout();
-  }, []);
+      fetchAbout();
+    }
+  }, [aboutLoaded]);
 
   if (loading) {
     return (

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -3,6 +3,7 @@ import HireMe from "@/components/HireMe";
 import { LinkArrow } from "@/components/Icons";
 import { Layout } from "@/components/Layout";
 import TransitionEffect from "@/components/TransitionEffect";
+import { useDataContext } from "@/contexts/DataContext";
 import { HomeContent } from "@/types";
 import urlConfig from "@/utils/urlConfig";
 import axios from "axios";
@@ -17,12 +18,14 @@ import lightBulb from "../../public/images/svgs/bulb.svg";
 const inter = Inter({ subsets: ["latin"] });
 
 export default function Home() {
-  const [homeContent, setHomeContent] = useState<HomeContent | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
+  const { homeData, setHomeData, homeLoaded, setHomeLoaded } = useDataContext();
+  const [loading, setLoading] = useState<boolean>(!homeLoaded);
 
   useEffect(() => {
-    fetchHomeContent();
-  }, []);
+    if (!homeLoaded) {
+      fetchHomeContent();
+    }
+  }, [homeLoaded]);
 
   const fetchHomeContent = async (): Promise<void> => {
     try {
@@ -30,10 +33,12 @@ export default function Home() {
         urlConfig.GET_HOME
       );
       if (response.data.data) {
-        setHomeContent(response.data.data);
+        setHomeData(response.data.data);
       }
+      setHomeLoaded(true);
     } catch (error) {
       console.error("Error fetching home content:", error);
+      setHomeLoaded(true);
     } finally {
       setLoading(false);
     }
@@ -41,14 +46,14 @@ export default function Home() {
 
   // Fallback content
   const heroText =
-    homeContent?.heroText ||
+    homeData?.heroText ||
     "Bringing Dreams to Life: Where Vision Meets Code and Design";
   const bioParagraph =
-    homeContent?.bioParagraph ||
+    homeData?.bioParagraph ||
     "As a seasoned software engineer with 5+ years of expertise, I specialize in crafting robust web solutions across healthcare and insurance sectors. From conceptualization to production deployment, I've architected scalable applications that drive business success. My passion lies in building intuitive, high-performance software that seamlessly bridges user needs with cutting-edge technology. I thrive on tackling complex challenges and continuously expanding my technical horizons to deliver exceptional digital experiences.";
   const profileImage: string | StaticImageData =
-    homeContent?.profileImage || profilepic;
-  const resumeLink = homeContent?.resumeLink || "/Feecon_resume_fullstack.pdf";
+    homeData?.profileImage || profilepic;
+  const resumeLink = homeData?.resumeLink || "/Feecon_resume_fullstack.pdf";
 
   if (loading) {
     return (

--- a/client/src/pages/projects.tsx
+++ b/client/src/pages/projects.tsx
@@ -3,7 +3,7 @@ import { AnimatedText } from "@/components/AnimatedText";
 import { GithubIcon } from "@/components/Icons";
 import { Layout } from "@/components/Layout";
 import TransitionEffect from "@/components/TransitionEffect";
-import { Project as ProjectType } from "@/types";
+import { useDataContext } from "@/contexts/DataContext";
 import urlConfig from "@/utils/urlConfig";
 import axios from "axios";
 import { motion } from "framer-motion";
@@ -166,25 +166,30 @@ const Project: React.FC<ProjectProps> = ({
   );
 };
 const Projects: React.FC = () => {
-  const [projects, setProjects] = useState<ProjectType[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
+  const { projectsData, setProjectsData, projectsLoaded, setProjectsLoaded } =
+    useDataContext();
+  const [loading, setLoading] = useState<boolean>(!projectsLoaded);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const fetchProjects = async () => {
-      try {
-        const response = await axios.get(urlConfig.GET_PROJECTS);
-        setProjects(response.data.data || []);
-        setLoading(false);
-      } catch (err) {
-        console.error("Error fetching projects:", err);
-        setError("Failed to load projects");
-        setLoading(false);
-      }
-    };
+    if (!projectsLoaded) {
+      const fetchProjects = async () => {
+        try {
+          const response = await axios.get(urlConfig.GET_PROJECTS);
+          setProjectsData(response.data.data || []);
+          setProjectsLoaded(true);
+          setLoading(false);
+        } catch (err) {
+          console.error("Error fetching projects:", err);
+          setError("Failed to load projects");
+          setProjectsLoaded(true);
+          setLoading(false);
+        }
+      };
 
-    fetchProjects();
-  }, []);
+      fetchProjects();
+    }
+  }, [projectsLoaded]);
 
   if (loading) {
     return (
@@ -260,13 +265,13 @@ const Projects: React.FC = () => {
             <div className="text-center text-red-500 dark:text-red-400">
               <p>{error}</p>
             </div>
-          ) : projects.length === 0 ? (
+          ) : projectsData.length === 0 ? (
             <div className="text-center text-dark dark:text-light">
               <p className="text-xl">No projects available yet.</p>
             </div>
           ) : (
             <div className="grid grid-cols-12 gap-24 gap-y-32 xl:gap-x-16 lg:gap-x-8 md:gap-y-24 sm:gap-x-0">
-              {projects.map((project, index) => {
+              {projectsData.map((project, index) => {
                 // Alternate between featured (full width) and regular projects
                 const isFeatured = index % 3 === 0;
 


### PR DESCRIPTION
- Create DataContext to cache home, about, projects data
- Wrap app with DataProvider in _app.tsx
- Update home, about, projects pages to use cached data
- Skip API calls when data already loaded
- Instant page loads on subsequent visits