### PR TITLE
feat: Move About link from NavBar to Footer

### DIFF
--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -25,12 +25,16 @@ export const Footer: React.FC = () => {
             </Link>
           </>
         ) : null}
-        <div>
+        <div className="flex items-center">
           Build with{" "}
           <span className="text-primary dark:text-primaryDark text-2xl px-1 lg:py-2">
             &#9825;
           </span>{" "}
           by <span className="underline underline-offset-2">Feecon</span>
+          <span className="mx-2">|</span>
+          <Link href="/about" className="underline underline-offset-2">
+            About Me
+          </Link>
         </div>
       </Layout>
     </footer>

--- a/client/src/components/NavBar.tsx
+++ b/client/src/components/NavBar.tsx
@@ -283,7 +283,6 @@ export const NavBar: React.FC = () => {
           ) : (
             <>
               <CustomLink href="/" title="Home" className="mr-4" />
-              <CustomLink href="/about" title="About" className="mx-4" />
               <CustomLink href="/projects" title="Projects" className="mx-4" />
               <CustomLink href="/blog" title="Blog" className="mx-4" />
               <DropdownMenu title="AI Solutions" className="inline-block mx-4">
@@ -419,12 +418,6 @@ export const NavBar: React.FC = () => {
                   <CustomMobileLink
                     href="/"
                     title="Home"
-                    className=""
-                    toggle={handleClick}
-                  />
-                  <CustomMobileLink
-                    href="/about"
-                    title="About"
                     className=""
                     toggle={handleClick}
                   />


### PR DESCRIPTION
- Removed About link from desktop and mobile navigation
- Added 'About Me' link to footer section
- Positioned next to 'Build with heart by Feecon' with pipe separator

closes #15 